### PR TITLE
Spike/451402 retrieve number of subsidiaries from within scheme registration frontend

### DIFF
--- a/src/FacadeAccountCreation/FacadeAccountCreation.API/Controllers/OrganisationsController.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.API/Controllers/OrganisationsController.cs
@@ -1,5 +1,4 @@
-﻿using Azure;
-using FacadeAccountCreation.API.Extensions;
+﻿using FacadeAccountCreation.API.Extensions;
 using FacadeAccountCreation.API.Shared;
 using FacadeAccountCreation.Core.Models.Organisations;
 using FacadeAccountCreation.Core.Models.Organisations.OrganisationUsers;
@@ -186,6 +185,26 @@ public class OrganisationsController : Controller
             return NoContent();
         }
     }
+
+    [HttpGet]
+    [Route("{organisationId:guid}/number-of-subsidiaries")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetOrganisationNumberOfSubsidiaries(Guid organisationId)
+    {
+        var organisationSubsidiaries = await _organisationService.ExportOrganisationSubsidiaries(organisationId);
+
+        if (organisationSubsidiaries != null)
+        {
+            return Ok(organisationSubsidiaries.Count(sub => sub.SubsidiaryId != null));
+        }
+        else
+        {
+            return NoContent();
+        }
+    }
+
     /// <summary>
     /// Updates the details of an organisation
     /// </summary>

--- a/src/FacadeAccountCreation/FacadeAccountCreation.API/Controllers/OrganisationsController.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.API/Controllers/OrganisationsController.cs
@@ -189,7 +189,6 @@ public class OrganisationsController : Controller
     [HttpGet]
     [Route("{organisationId:guid}/number-of-subsidiaries")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> GetOrganisationNumberOfSubsidiaries(Guid organisationId)
     {
@@ -199,10 +198,7 @@ public class OrganisationsController : Controller
         {
             return Ok(organisationSubsidiaries.Count(sub => sub.SubsidiaryId != null));
         }
-        else
-        {
-            return NoContent();
-        }
+        return Ok(0);
     }
 
     /// <summary>
@@ -239,7 +235,7 @@ public class OrganisationsController : Controller
         }
         catch (Exception e)
         {
-            _logger.LogError($"Error updating the nation Id for organisation {id}");
+            _logger.LogError(e, "Error updating the nation Id for organisation {Id}", id);
             return HandleError.Handle(e);
         }
     }

--- a/src/FacadeAccountCreation/FacadeAccountCreation.Core/Services/Organisation/OrganisationService.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.Core/Services/Organisation/OrganisationService.cs
@@ -7,7 +7,6 @@ using FacadeAccountCreation.Core.Models.Subsidiary;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 using System.Net;
 using System.Net.Http.Json;
 
@@ -104,7 +103,7 @@ public class OrganisationService : IOrganisationService
         var nationLookup = new NationLookup();
         var nationName = nationLookup.GetNationName(nationId);
         var url = $"{_config.GetSection("RegulatorOrganisationEndpoints").GetSection("GetOrganisationIdFromNation").Value}{nationName}";
-        _logger.LogInformation("Attempting to fetch the Regulator Organisation for nation id {nationName} from the backend", nationName);
+        _logger.LogInformation("Attempting to fetch the Regulator Organisation for nation id {NationName} from the backend", nationName);
 
         var response = await _httpClient.GetAsync(url);
 
@@ -204,6 +203,10 @@ public class OrganisationService : IOrganisationService
 
             var response = await _httpClient.GetAsync(endpoint);
 
+            if (string.IsNullOrEmpty(await response.Content.ReadAsStringAsync()))
+            {
+                return null;
+            }
             return await response.Content.ReadFromJsonWithEnumsAsync<List<ExportOrganisationSubsidiariesResponseModel>>();
         }
         catch (Exception e)

--- a/src/FacadeAccountCreation/FacadeAccountCreation.UnitTests/API/Controllers/OrganisationsControllerTests.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.UnitTests/API/Controllers/OrganisationsControllerTests.cs
@@ -384,6 +384,31 @@ public class OrganisationsControllerTests
     }
 
     [TestMethod]
+    public async Task GetOrganisationNumberOfSubsidiaries_ValidInputData_ReturnsCorrectCount()
+    {
+        // Arrange
+        var organisationId = Guid.NewGuid();
+        var mockResponse = new List<ExportOrganisationSubsidiariesResponseModel>
+        {
+            new ExportOrganisationSubsidiariesResponseModel {
+                OrganisationId = "12", SubsidiaryId = "ABCD1234", OrganisationName = "Some Corporation", CompaniesHouseNumber = "CH1"
+            },
+            new ExportOrganisationSubsidiariesResponseModel {
+                OrganisationId = "13", SubsidiaryId = "EFGH1234", OrganisationName = "ABC Trading", CompaniesHouseNumber = "101234"
+            }
+        };
+
+        _mockOrganisationService.Setup(service => service.ExportOrganisationSubsidiaries(organisationId)).ReturnsAsync(mockResponse);
+
+        // Act
+        var result = await _sut.GetOrganisationNumberOfSubsidiaries(organisationId);
+
+        // Assert
+        var okResult = result as OkObjectResult;
+        Assert.AreEqual(okResult.Value, mockResponse.Count);
+    }
+
+    [TestMethod]
     public async Task GetExportOrganisationSubsidiariesAsync_ValidInputWithNoData_ReturnsNoContentResult()
     {
         // Arrange


### PR DESCRIPTION
Added endpoint number-of-subsidiaries to return an organisation's number of subsidiaries.