### PR TITLE
Cherry pick Boomi changes into Release 6.4.0

### DIFF
--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -48,7 +48,7 @@ resources:
     - repository: AutomationTesting
       name: RWD-CPR-EPR4P-ADO/epr-playwright-bdd
       type: git
-      ref: 508473-automation-testing-test
+      ref: develop
  
 
 stages:

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -48,7 +48,8 @@ resources:
     - repository: AutomationTesting
       name: RWD-CPR-EPR4P-ADO/epr-playwright-bdd
       type: git
-      ref: automation-testing-build-pipeline
+      ref: 508473-automation-testing-test
+ 
 
 stages:
 - template: epr-build-pipeline.yaml@CommonTemplates

--- a/pipelines/templates/stage-deploy-template.yaml
+++ b/pipelines/templates/stage-deploy-template.yaml
@@ -26,6 +26,6 @@ stages:
           dependsOn: DeployToDev4Regulators
           steps:
             - checkout: AutomationTesting
-            - template: automation-testing-regulators.yaml@AutomationTesting
+            - template: pipelines/automation-testing-template.yml@AutomationTesting
               parameters:
                 env: 'dev4'

--- a/src/FacadeAccountCreation/FacadeAccountCreation.API/Configs/ApiConfig.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.API/Configs/ApiConfig.cs
@@ -17,4 +17,14 @@ public class ApiConfig
     public string Certificate { get; set; } = null!;
 
     public int Timeout { get; set; }
+
+    public string TenantId { get; set; }
+
+    public string AddressLookupScope { get; set; }
+
+    public string CompaniesHouseScope { get; set; }
+
+    public string ClientId { get; set; }
+
+    public string ClientSecret { get; set; }
 }

--- a/src/FacadeAccountCreation/FacadeAccountCreation.API/Constants/Client.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.API/Constants/Client.cs
@@ -1,0 +1,9 @@
+﻿namespace FacadeAccountCreation.API.Constants;
+
+public static class Client
+{
+    //
+    // Summary:
+    //     Bearer. Predominant type of access token used with OAuth 2.0.
+    public const string Bearer = "Bearer";
+}

--- a/src/FacadeAccountCreation/FacadeAccountCreation.API/Handlers/AddressLookupCredentialHandler.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.API/Handlers/AddressLookupCredentialHandler.cs
@@ -1,0 +1,30 @@
+﻿using Azure.Core;
+using Azure.Identity;
+using FacadeAccountCreation.API.Configs;
+using Microsoft.Extensions.Options;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http.Headers;
+
+namespace FacadeAccountCreation.API.Handlers;
+
+[ExcludeFromCodeCoverage]
+public class AddressLookupCredentialHandler : DelegatingHandler
+{
+    private readonly TokenRequestContext _tokenRequestContext;
+    private readonly ClientSecretCredential _credentials;
+
+    public AddressLookupCredentialHandler(IOptions<ApiConfig> options)
+    {
+        var clientApiOptions = options.Value;
+        _tokenRequestContext = new TokenRequestContext(new[] { clientApiOptions.AddressLookupScope });
+        _credentials = new ClientSecretCredential(clientApiOptions.TenantId, clientApiOptions.ClientId, clientApiOptions.ClientSecret);
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var tokenResult = await _credentials.GetTokenAsync(_tokenRequestContext, cancellationToken);
+        request.Headers.Authorization = new AuthenticationHeaderValue(Constants.Client.Bearer, tokenResult.Token);
+
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/FacadeAccountCreation/FacadeAccountCreation.API/Handlers/CompaniesHouseCredentialHandler.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.API/Handlers/CompaniesHouseCredentialHandler.cs
@@ -1,0 +1,30 @@
+﻿using Azure.Core;
+using Azure.Identity;
+using FacadeAccountCreation.API.Configs;
+using Microsoft.Extensions.Options;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http.Headers;
+
+namespace FacadeAccountCreation.API.Handlers;
+
+[ExcludeFromCodeCoverage]
+public class CompaniesHouseCredentialHandler : DelegatingHandler
+{
+    private readonly TokenRequestContext _tokenRequestContext;
+    private readonly ClientSecretCredential _credentials;
+
+    public CompaniesHouseCredentialHandler(IOptions<ApiConfig> options)
+    {
+        var clientApiOptions = options.Value;
+        _tokenRequestContext = new TokenRequestContext(new[] { clientApiOptions.CompaniesHouseScope });
+        _credentials = new ClientSecretCredential(clientApiOptions.TenantId, clientApiOptions.ClientId, clientApiOptions.ClientSecret);
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var tokenResult = await _credentials.GetTokenAsync(_tokenRequestContext, cancellationToken);
+        request.Headers.Authorization = new AuthenticationHeaderValue(Constants.Client.Bearer, tokenResult.Token);
+
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/FacadeAccountCreation/FacadeAccountCreation.API/appsettings.json
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.API/appsettings.json
@@ -18,10 +18,14 @@
   "ApiConfig": {
     "AddressLookupBaseUrl": "",
     "CompaniesHouseLookupBaseUrl": "",
-    "Certificate": "",
     "Timeout": 30,
     "AccountServiceBaseUrl": "",
-    "AccountServiceClientId": ""
+    "AccountServiceClientId": "",
+    "TenantId": "",
+    "AddressLookupScope": "",
+    "CompaniesHouseScope": "",
+    "ClientId": "",
+    "ClientSecret": ""
   },
   "ComplianceSchemeEndpoints": {
     "Remove": "api/compliance-schemes/remove/",
@@ -90,7 +94,8 @@
     "NorthernIreland": "EPRCustomerService@defra.gov.uk"
   },
   "FeatureManagement": {
-    "SendDissociationNotificationEmail": false
+    "SendDissociationNotificationEmail": false,
+    "UseBoomiOAuth": false
   },
   "rolesConfig": {
     "roles": [

--- a/src/FacadeAccountCreation/FacadeAccountCreation.Core/Constants/FeatureFlags.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.Core/Constants/FeatureFlags.cs
@@ -3,4 +3,5 @@
 public static class FeatureFlags
 {
     public const string SendDissociationNotificationEmail = "SendDissociationNotificationEmail";
+    public const string UseBoomiOAuth = "UseBoomiOAuth";
 }

--- a/src/FacadeAccountCreation/FacadeAccountCreation.UnitTests/Core/Services/CompaniesHouseServiceTests.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.UnitTests/Core/Services/CompaniesHouseServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using AutoFixture;
 using AutoFixture.AutoMoq;
+using FacadeAccountCreation.Core.Constants;
 using FacadeAccountCreation.Core.Models.CompaniesHouse;
 using FacadeAccountCreation.Core.Services.CompaniesHouse;
 using FluentAssertions;
@@ -7,19 +8,31 @@ using Moq;
 using Moq.Protected;
 using System.Net;
 using System.Text.Json;
+using Microsoft.FeatureManagement;
 
 namespace FacadeAccountCreation.UnitTests.Core.Services;
 
 [TestClass]
 public class CompaniesHouseServiceTests
 {
-    private const string CompaniesHouseEndpoint = "CompaniesHouse/companies";
+    private const string CompaniesHouseEndpointForOAuth = "companies";
+    private const string CompaniesHouseEndpointForCertificateAuth = "CompaniesHouse/companies";
     private const string CompaniesHouseNumber = "DummyCompaniesHouseNumber";
     private const string BaseAddress = "http://localhost";
-    private const string ExpectedUrl = $"{BaseAddress}/{CompaniesHouseEndpoint}/{CompaniesHouseNumber}";
+    private const string ExpectedUrl = $"{BaseAddress}/{CompaniesHouseEndpointForOAuth}/{CompaniesHouseNumber}";
+    private const string ExpectedUrlForCertificateAuth = $"{BaseAddress}/{CompaniesHouseEndpointForCertificateAuth}/{CompaniesHouseNumber}";
 
     private readonly IFixture _fixture = new Fixture().Customize(new AutoMoqCustomization());
+    private readonly Mock<IFeatureManager> _featureManagerMock = new();
     private readonly Mock<HttpMessageHandler> _httpMessageHandlerMock = new();
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        _featureManagerMock
+            .Setup(x => x.IsEnabledAsync(FeatureFlags.UseBoomiOAuth))
+            .ReturnsAsync(true);
+    }
 
     [TestMethod]
     public async Task Should_return_correct_companies_house_lookup_response()
@@ -40,7 +53,7 @@ public class CompaniesHouseServiceTests
         var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
         httpClient.BaseAddress = new Uri(BaseAddress);
 
-        var sut = new CompaniesHouseLookupService(httpClient);
+        var sut = new CompaniesHouseLookupService(httpClient, _featureManagerMock.Object);
 
         // Act
         var result = await sut.GetCompaniesHouseResponseAsync(CompaniesHouseNumber);
@@ -51,6 +64,45 @@ public class CompaniesHouseServiceTests
                 req => req.Method == HttpMethod.Get &&
                        req.RequestUri != null &&
                        req.RequestUri.ToString() == ExpectedUrl),
+            ItExpr.IsAny<CancellationToken>());
+
+        result.Should().BeOfType<CompaniesHouseResponse>();
+    }
+
+    [TestMethod]
+    public async Task Should_return_correct_companies_house_lookup_response_when_feature_flag_is_on()
+    {
+        // Arrange
+        var apiResponse = _fixture.Create<CompaniesHouseResponse>();
+
+        _featureManagerMock
+            .Setup(x => x.IsEnabledAsync(FeatureFlags.UseBoomiOAuth))
+            .ReturnsAsync(false);
+
+        _httpMessageHandlerMock.Protected()
+             .Setup<Task<HttpResponseMessage>>("SendAsync",
+                 ItExpr.Is<HttpRequestMessage>(x => x.RequestUri != null && x.RequestUri.ToString() == ExpectedUrlForCertificateAuth),
+                 ItExpr.IsAny<CancellationToken>())
+             .ReturnsAsync(new HttpResponseMessage
+             {
+                 StatusCode = HttpStatusCode.OK,
+                 Content = new StringContent(JsonSerializer.Serialize(apiResponse))
+             }).Verifiable();
+
+        var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
+        httpClient.BaseAddress = new Uri(BaseAddress);
+
+        var sut = new CompaniesHouseLookupService(httpClient, _featureManagerMock.Object);
+
+        // Act
+        var result = await sut.GetCompaniesHouseResponseAsync(CompaniesHouseNumber);
+
+        // Assert
+        _httpMessageHandlerMock.Protected().Verify("SendAsync", Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(
+                req => req.Method == HttpMethod.Get &&
+                       req.RequestUri != null &&
+                       req.RequestUri.ToString() == ExpectedUrlForCertificateAuth),
             ItExpr.IsAny<CancellationToken>());
 
         result.Should().BeOfType<CompaniesHouseResponse>();
@@ -84,7 +136,7 @@ public class CompaniesHouseServiceTests
         var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
         httpClient.BaseAddress = new Uri(BaseAddress);
 
-        var sut = new CompaniesHouseLookupService(httpClient);
+        var sut = new CompaniesHouseLookupService(httpClient, _featureManagerMock.Object);
 
         // Act
         var exception = await Assert.ThrowsExceptionAsync<HttpRequestException>(() => sut.GetCompaniesHouseResponseAsync(CompaniesHouseNumber));
@@ -124,7 +176,7 @@ public class CompaniesHouseServiceTests
         var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
         httpClient.BaseAddress = new Uri(BaseAddress);
 
-        var sut = new CompaniesHouseLookupService(httpClient);
+        var sut = new CompaniesHouseLookupService(httpClient, _featureManagerMock.Object);
 
         // Act
         var result = await sut.GetCompaniesHouseResponseAsync(CompaniesHouseNumber);


### PR DESCRIPTION
Had to fix some using statements as main/R8.0  has been refactored with GlobalUsings
* initial POC

* final fixes

* fixes for co house

* co house fixes

* fixed unit test

* rebuild for PR

* Remove obsolete code, exclude handlers from sonar chacks

* Add new boomi settings to appsettings.json

* Add boomi feature flag, put certificate back

---------

Co-authored-by: Mike Wild <Michael.Wild@defra.onmicrosoft.com>
# Conflicts:
#	src/FacadeAccountCreation/FacadeAccountCreation.API/Extensions/HttpClientServiceCollectionExtension.cs #	src/FacadeAccountCreation/FacadeAccountCreation.Core/Services/CompaniesHouse/CompaniesHouseLookupService.cs #	src/FacadeAccountCreation/FacadeAccountCreation.UnitTests/Core/Services/CompaniesHouseServiceTests.cs