### PR TITLE
AB#536457 Remove old boomi certificate auth

### DIFF
--- a/src/FacadeAccountCreation/FacadeAccountCreation.API/Configs/ApiConfig.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.API/Configs/ApiConfig.cs
@@ -15,8 +15,6 @@ public class ApiConfig
 
     public string AccountServiceClientId { get; set; } = null!;
 
-    public string Certificate { get; set; } = null!;
-
     public int Timeout { get; set; }
 
     public string TenantId { get; set; }

--- a/src/FacadeAccountCreation/FacadeAccountCreation.API/Extensions/HttpClientServiceCollectionExtension.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.API/Extensions/HttpClientServiceCollectionExtension.cs
@@ -1,5 +1,4 @@
 ﻿using FacadeAccountCreation.API.Handlers;
-using FacadeAccountCreation.Core.Constants;
 using FacadeAccountCreation.Core.Services.AddressLookup;
 using FacadeAccountCreation.Core.Services.CompaniesHouse;
 using FacadeAccountCreation.Core.Services.ComplianceScheme;
@@ -7,9 +6,6 @@ using FacadeAccountCreation.Core.Services.Enrolments;
 using FacadeAccountCreation.Core.Services.Notification;
 using FacadeAccountCreation.Core.Services.RoleManagement;
 using FacadeAccountCreation.Core.Services.User;
-using Microsoft.FeatureManagement;
-using System.Security.Authentication;
-using System.Security.Cryptography.X509Certificates;
 
 namespace FacadeAccountCreation.API.Extensions;
 
@@ -17,11 +13,6 @@ public static class HttpClientServiceCollectionExtension
 {
     public static IServiceCollection AddServicesAndHttpClients(this IServiceCollection services)
     {
-        var serviceProvider = services.BuildServiceProvider();
-
-        var featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
-        var useBoomiOAuth = featureManager.IsEnabledAsync(FeatureFlags.UseBoomiOAuth).GetAwaiter().GetResult();
-
         services.AddTransient<AccountServiceAuthorisationHandler>();
         services.AddTransient<AddressLookupCredentialHandler>();
         services.AddTransient<CompaniesHouseCredentialHandler>();
@@ -33,7 +24,7 @@ public static class HttpClientServiceCollectionExtension
             client.BaseAddress = new Uri(config.AddressLookupBaseUrl);
             client.Timeout = TimeSpan.FromSeconds(config.Timeout);
         })
-        .AddAddressLookupCredentialHandler(useBoomiOAuth);
+            .AddHttpMessageHandler<AddressLookupCredentialHandler>();
 
         services.AddHttpClient<ICompaniesHouseLookupService, CompaniesHouseLookupService>((sp, client) =>
         {
@@ -42,7 +33,7 @@ public static class HttpClientServiceCollectionExtension
             client.BaseAddress = new Uri(config.CompaniesHouseLookupBaseUrl);
             client.Timeout = TimeSpan.FromSeconds(config.Timeout);
         })
-            .AddCompaniesHouseCredentialHandler(useBoomiOAuth);
+            .AddHttpMessageHandler<CompaniesHouseCredentialHandler>();
 
         services.AddHttpClient<IComplianceSchemeService, ComplianceSchemeService>((sp, client) =>
         {
@@ -117,51 +108,5 @@ public static class HttpClientServiceCollectionExtension
         .AddHttpMessageHandler<AccountServiceAuthorisationHandler>();
 
         return services;
-    }
-
-    public static IHttpClientBuilder AddAddressLookupCredentialHandler(this IHttpClientBuilder builder, bool useBoomiOAuth)
-    {
-        if (useBoomiOAuth)
-        {
-            builder.AddHttpMessageHandler<AddressLookupCredentialHandler>();
-        }
-        else
-        {
-            builder.ConfigurePrimaryHttpMessageHandler(GetClientCertificateHandler);
-        }
-
-        return builder;
-    }
-
-    public static IHttpClientBuilder AddCompaniesHouseCredentialHandler(this IHttpClientBuilder builder, bool useBoomiOAuth)
-    {
-        if (useBoomiOAuth)
-        {
-            builder.AddHttpMessageHandler<CompaniesHouseCredentialHandler>();
-        }
-        else
-        {
-            builder.ConfigurePrimaryHttpMessageHandler(GetClientCertificateHandler);
-        }
-
-        return builder;
-    }
-
-    private static HttpMessageHandler GetClientCertificateHandler(IServiceProvider sp)
-    {
-        if (sp == null)
-        {
-            throw new ArgumentException("ServiceProvider must not be null");
-        }
-
-        var handler = new HttpClientHandler();
-        handler.ClientCertificateOptions = ClientCertificateOption.Manual;
-        handler.SslProtocols = SslProtocols.Tls12;
-        handler.ClientCertificates
-            .Add(new X509Certificate2(
-                Convert.FromBase64String(sp.GetRequiredService<IOptions<ApiConfig>>().Value.Certificate))
-            );
-
-        return handler;
     }
 }

--- a/src/FacadeAccountCreation/FacadeAccountCreation.API/appsettings.json
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.API/appsettings.json
@@ -100,8 +100,7 @@
     "NorthernIreland": "EPRCustomerService@defra.gov.uk"
   },
   "FeatureManagement": {
-    "SendDissociationNotificationEmail": false,
-    "UseBoomiOAuth": false
+    "SendDissociationNotificationEmail": false
   },
   "rolesConfig": {
     "roles": [

--- a/src/FacadeAccountCreation/FacadeAccountCreation.Core/Constants/FeatureFlags.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.Core/Constants/FeatureFlags.cs
@@ -3,5 +3,4 @@
 public static class FeatureFlags
 {
     public const string SendDissociationNotificationEmail = "SendDissociationNotificationEmail";
-    public const string UseBoomiOAuth = "UseBoomiOAuth";
 }

--- a/src/FacadeAccountCreation/FacadeAccountCreation.Core/Services/CompaniesHouse/CompaniesHouseLookupService.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.Core/Services/CompaniesHouse/CompaniesHouseLookupService.cs
@@ -1,16 +1,9 @@
-﻿using FacadeAccountCreation.Core.Constants;
-using Microsoft.FeatureManagement;
-
-namespace FacadeAccountCreation.Core.Services.CompaniesHouse;
+﻿namespace FacadeAccountCreation.Core.Services.CompaniesHouse;
 
 public class CompaniesHouseLookupService(
-    HttpClient httpClient,
-    IFeatureManager featureManager) : ICompaniesHouseLookupService
+    HttpClient httpClient) : ICompaniesHouseLookupService
 {
-    private string CompaniesHouseEndpoint { get; } = 
-        featureManager.IsEnabledAsync(FeatureFlags.UseBoomiOAuth).GetAwaiter().GetResult()
-            ? "companies"
-            : "CompaniesHouse/companies";
+    private const string CompaniesHouseEndpoint = "companies";
 
     public async Task<CompaniesHouseResponse?> GetCompaniesHouseResponseAsync(string id)
     {

--- a/src/FacadeAccountCreation/FacadeAccountCreation.UnitTests/Core/Services/CompaniesHouseServiceTests.cs
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.UnitTests/Core/Services/CompaniesHouseServiceTests.cs
@@ -1,31 +1,18 @@
-﻿using FacadeAccountCreation.Core.Constants;
-using FacadeAccountCreation.Core.Models.CompaniesHouse;
+﻿using FacadeAccountCreation.Core.Models.CompaniesHouse;
 using FacadeAccountCreation.Core.Services.CompaniesHouse;
-using Microsoft.FeatureManagement;
 
 namespace FacadeAccountCreation.UnitTests.Core.Services;
 
 [TestClass]
 public class CompaniesHouseServiceTests
 {
-    private const string CompaniesHouseEndpointForOAuth = "companies";
-    private const string CompaniesHouseEndpointForCertificateAuth = "CompaniesHouse/companies";
+    private const string CompaniesHouseEndpoint = "companies";
     private const string CompaniesHouseNumber = "DummyCompaniesHouseNumber";
     private const string BaseAddress = "http://localhost";
-    private const string ExpectedUrl = $"{BaseAddress}/{CompaniesHouseEndpointForOAuth}/{CompaniesHouseNumber}";
-    private const string ExpectedUrlForCertificateAuth = $"{BaseAddress}/{CompaniesHouseEndpointForCertificateAuth}/{CompaniesHouseNumber}";
+    private const string ExpectedUrl = $"{BaseAddress}/{CompaniesHouseEndpoint}/{CompaniesHouseNumber}";
 
     private readonly IFixture _fixture = new Fixture().Customize(new AutoMoqCustomization());
-    private readonly Mock<IFeatureManager> _featureManagerMock = new();
     private readonly Mock<HttpMessageHandler> _httpMessageHandlerMock = new();
-
-    [TestInitialize]
-    public void TestInitialize()
-    {
-        _featureManagerMock
-            .Setup(x => x.IsEnabledAsync(FeatureFlags.UseBoomiOAuth))
-            .ReturnsAsync(true);
-    }
 
     [TestMethod]
     public async Task Should_return_correct_companies_house_lookup_response()
@@ -46,7 +33,7 @@ public class CompaniesHouseServiceTests
         var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
         httpClient.BaseAddress = new Uri(BaseAddress);
 
-        var sut = new CompaniesHouseLookupService(httpClient, _featureManagerMock.Object);
+        var sut = new CompaniesHouseLookupService(httpClient);
 
         // Act
         var result = await sut.GetCompaniesHouseResponseAsync(CompaniesHouseNumber);
@@ -57,45 +44,6 @@ public class CompaniesHouseServiceTests
                 req => req.Method == HttpMethod.Get &&
                        req.RequestUri != null &&
                        req.RequestUri.ToString() == ExpectedUrl),
-            ItExpr.IsAny<CancellationToken>());
-
-        result.Should().BeOfType<CompaniesHouseResponse>();
-    }
-
-    [TestMethod]
-    public async Task Should_return_correct_companies_house_lookup_response_when_feature_flag_is_on()
-    {
-        // Arrange
-        var apiResponse = _fixture.Create<CompaniesHouseResponse>();
-
-        _featureManagerMock
-            .Setup(x => x.IsEnabledAsync(FeatureFlags.UseBoomiOAuth))
-            .ReturnsAsync(false);
-
-        _httpMessageHandlerMock.Protected()
-             .Setup<Task<HttpResponseMessage>>("SendAsync",
-                 ItExpr.Is<HttpRequestMessage>(x => x.RequestUri != null && x.RequestUri.ToString() == ExpectedUrlForCertificateAuth),
-                 ItExpr.IsAny<CancellationToken>())
-             .ReturnsAsync(new HttpResponseMessage
-             {
-                 StatusCode = HttpStatusCode.OK,
-                 Content = new StringContent(JsonSerializer.Serialize(apiResponse))
-             }).Verifiable();
-
-        var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
-        httpClient.BaseAddress = new Uri(BaseAddress);
-
-        var sut = new CompaniesHouseLookupService(httpClient, _featureManagerMock.Object);
-
-        // Act
-        var result = await sut.GetCompaniesHouseResponseAsync(CompaniesHouseNumber);
-
-        // Assert
-        _httpMessageHandlerMock.Protected().Verify("SendAsync", Times.Once(),
-            ItExpr.Is<HttpRequestMessage>(
-                req => req.Method == HttpMethod.Get &&
-                       req.RequestUri != null &&
-                       req.RequestUri.ToString() == ExpectedUrlForCertificateAuth),
             ItExpr.IsAny<CancellationToken>());
 
         result.Should().BeOfType<CompaniesHouseResponse>();
@@ -129,7 +77,7 @@ public class CompaniesHouseServiceTests
         var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
         httpClient.BaseAddress = new Uri(BaseAddress);
 
-        var sut = new CompaniesHouseLookupService(httpClient, _featureManagerMock.Object);
+        var sut = new CompaniesHouseLookupService(httpClient);
 
         // Act
         var exception = await Assert.ThrowsExceptionAsync<HttpRequestException>(() => sut.GetCompaniesHouseResponseAsync(CompaniesHouseNumber));
@@ -169,7 +117,7 @@ public class CompaniesHouseServiceTests
         var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
         httpClient.BaseAddress = new Uri(BaseAddress);
 
-        var sut = new CompaniesHouseLookupService(httpClient, _featureManagerMock.Object);
+        var sut = new CompaniesHouseLookupService(httpClient);
 
         // Act
         var result = await sut.GetCompaniesHouseResponseAsync(CompaniesHouseNumber);

--- a/src/FacadeAccountCreation/FacadeAccountCreation.UnitTests/FacadeAccountCreation.UnitTests.csproj
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.UnitTests/FacadeAccountCreation.UnitTests.csproj
@@ -15,7 +15,7 @@
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.18.1" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-        <PackageReference Include="FluentAssertions" Version="6.12.2" />
+        <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="ILogger.Moq" Version="1.1.10" />


### PR DESCRIPTION
Removed old Boomi certificate configuration and feature flag, which are no longer needed because migration to OAuth is now complete.

Other changes:

 - updated and locked FluentAssertions nuget to version '7.2.0' which is the last non-commercial version