### PR TITLE
SUB-298: Upgrade to .NET 10

### DIFF
--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -17,7 +17,7 @@ parameters:
     # - 'SonarQubeLatest'
     
 
-pool: DEFRA-COMMON-ubuntu2004-SSV3
+pool: DEFRA-COMMON-UBUNTU-SSV3
 
 variables:
   - template: vars/DEV4-development.yaml
@@ -36,7 +36,7 @@ variables:
   - name: runTests
     value: true
   - name: dotnetVersion
-    value: dotnetVersion8
+    value: dotnetVersion10
 
   - name: additionalDeployments
     value: true
@@ -46,8 +46,9 @@ resources:
 
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
+      endpoint: defra
       ref: main
 
 extends:

--- a/pipelines/deployment-pipeline-regulator.yaml
+++ b/pipelines/deployment-pipeline-regulator.yaml
@@ -1,6 +1,6 @@
 trigger: none
 pr: none
-pool: DEFRA-COMMON-ubuntu2204-SSV3
+pool: DEFRA-COMMON-UBUNTU-SSV3
 appendCommitMessageToRunName: false
 name: 'Deploy code to $(serviceName)'
 

--- a/pipelines/deployment-pipeline.yaml
+++ b/pipelines/deployment-pipeline.yaml
@@ -1,6 +1,6 @@
 trigger: none
 pr: none
-pool: DEFRA-COMMON-ubuntu2204-SSV3
+pool: DEFRA-COMMON-UBUNTU-SSV3
 appendCommitMessageToRunName: false
 name: 'Deploy code to $(serviceName)'
 

--- a/src/FacadeAccountCreation/FacadeAccountCreation.API/Dockerfile
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.API/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM defradigital/dotnetcore:dotnet8.0 AS base
+﻿FROM defradigital/dotnetcore:dotnet10.0 AS base
 USER root
 ENV ASPNETCORE_URLS=http://*:8080
 EXPOSE 8080
@@ -6,7 +6,7 @@ EXPOSE 8080
 RUN apk update && apk --no-cache add icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=0
  
-FROM defradigital/dotnetcore-development:dotnet8.0 AS build
+FROM defradigital/dotnetcore-development:dotnet10.0 AS build
 USER root
 WORKDIR /src
 COPY ["FacadeAccountCreation.API/FacadeAccountCreation.API.csproj", "FacadeAccountCreation.API/"]

--- a/src/FacadeAccountCreation/FacadeAccountCreation.API/FacadeAccountCreation.API.csproj
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.API/FacadeAccountCreation.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
@@ -13,11 +13,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.16.0" />
+        <PackageReference Include="Azure.Identity" Version="1.17.2" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Identity.Web" Version="3.14.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Identity.Web" Version="4.11.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
     </ItemGroup>
 

--- a/src/FacadeAccountCreation/FacadeAccountCreation.Core/FacadeAccountCreation.Core.csproj
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.Core/FacadeAccountCreation.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>FacadeAccountCreation.Core</AssemblyName>
@@ -16,11 +16,10 @@
     <PackageReference Include="Enums.NET" Version="5.0.0" />
     <PackageReference Include="EPR.Common.Logging" Version="1.0.7" />
     <PackageReference Include="GovukNotify" Version="7.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FacadeAccountCreation/FacadeAccountCreation.UnitTests/FacadeAccountCreation.UnitTests.csproj
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.UnitTests/FacadeAccountCreation.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -15,7 +15,7 @@
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.18.1" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-        <PackageReference Include="Azure.Identity" Version="1.16.0" />
+        <PackageReference Include="Azure.Identity" Version="1.17.2" />
         <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
@@ -31,8 +31,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
-        <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Bump target framework from net8.0 to net10.0 across API, Core, and UnitTests projects. Update Dockerfile base images to defradigital dotnet10.0 and set build pipeline dotnetVersion to dotnetVersion10.

Bump framework-paired packages to 10.0.0 (Microsoft.AspNetCore. Authentication.JwtBearer, Microsoft.Extensions.Configuration, Microsoft.Extensions.Logging). Remove now-redundant explicit references pruned by the .NET 10 SDK (Microsoft.Extensions.Http, System.Text.Encodings.Web, System.Net.Http, System.Text.RegularExpressions) to clear NU1510.

Upgrade Microsoft.Identity.Web 3.14.1 -> 4.11.0 and Azure.Identity 1.16.0 -> 1.17.2 to pull in patched transitive System.Security. Cryptography.Xml and resolve NU1903 (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf).

Switch pipeline pools to the new build agents and point CommonTemplates at the GitHub repo.