### PR TITLE
SUB-344: Fix Docker build context and trim redundant Dockerfile steps

### DIFF
--- a/src/FacadeAccountCreation/.dockerignore
+++ b/src/FacadeAccountCreation/.dockerignore
@@ -1,4 +1,4 @@
-﻿**/.dockerignore
+**/.dockerignore
 **/.env
 **/.git
 **/.gitignore
@@ -8,7 +8,10 @@
 **/.vs
 **/.vscode
 **/.idea
+**/.claude
 **/*.*proj.user
+**/*.user
+**/*.DotSettings*
 **/*.dbmdl
 **/*.jfm
 **/azds.yaml
@@ -21,5 +24,6 @@
 **/obj
 **/secrets.dev.yaml
 **/values.dev.yaml
+**/TestResults
 LICENSE
 README.md

--- a/src/FacadeAccountCreation/FacadeAccountCreation.API/Dockerfile
+++ b/src/FacadeAccountCreation/FacadeAccountCreation.API/Dockerfile
@@ -3,7 +3,7 @@ USER root
 ENV ASPNETCORE_URLS=http://*:8080
 EXPOSE 8080
  
-RUN apk update && apk --no-cache add icu-libs
+RUN apk add --no-cache icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=0
  
 FROM defradigital/dotnetcore-development:dotnet10.0 AS build
@@ -21,7 +21,6 @@ RUN dotnet restore "FacadeAccountCreation.API/FacadeAccountCreation.API.csproj" 
 COPY FacadeAccountCreation.API/. ./FacadeAccountCreation.API/.
 COPY FacadeAccountCreation.Core/. ./FacadeAccountCreation.Core/.
 WORKDIR "/src/FacadeAccountCreation.API"
-RUN dotnet build "FacadeAccountCreation.API.csproj" -c Release -o /app/build
 
 FROM build AS publish
 RUN dotnet publish "FacadeAccountCreation.API.csproj" -c Release -o /app/publish
@@ -34,5 +33,4 @@ USER dotnet
  
 WORKDIR /app
 COPY --from=publish /app/publish .
-USER dotnet
 ENTRYPOINT ["dotnet", "FacadeAccountCreation.API.dll"]


### PR DESCRIPTION
Move .dockerignore to the build context root (src/FacadeAccountCreation) so it is actually applied — previously it sat in the API project folder where Docker never reads it, letting host bin/obj into the build stage. Also add TestResults, *.user, *.DotSettings* and .claude to the ignores.

Drop the unused `dotnet build` step (publish recompiles anyway), replace `apk update && apk --no-cache add` with `apk add --no-cache`, and remove the duplicate USER dotnet.